### PR TITLE
Add configurable PIL image limits for terminal color theming

### DIFF
--- a/.config/quickshell/ii/modules/common/Config.qml
+++ b/.config/quickshell/ii/modules/common/Config.qml
@@ -86,6 +86,7 @@ Singleton {
                     property bool enableAppsAndShell: true
                     property bool enableQtApps: true
                     property bool enableTerminal: true
+                    property int maxImagePixels: 200000000 // ~200MP limit, set to 0 for unlimited
                 }
                 property JsonObject palette: JsonObject {
                     property string type: "auto" // Allowed: auto, scheme-content, scheme-expressive, scheme-fidelity, scheme-fruit-salad, scheme-monochrome, scheme-neutral, scheme-rainbow, scheme-tonal-spot

--- a/.config/quickshell/ii/modules/settings/AdvancedConfig.qml
+++ b/.config/quickshell/ii/modules/settings/AdvancedConfig.qml
@@ -41,5 +41,22 @@ ContentPage {
             }
 
         }
+        
+        ConfigRow {
+            uniform: true
+            ConfigSpinBox {
+                text: Translation.tr("Max image pixels (millions)")
+                value: Math.round((Config.options.appearance.wallpaperTheming.maxImagePixels || 200000000) / 1000000)
+                onValueChanged: {
+                    Config.options.appearance.wallpaperTheming.maxImagePixels = value === 0 ? 0 : value * 1000000;
+                }
+                from: 0
+                to: 1000
+                stepSize: 50
+                StyledToolTip {
+                    content: Translation.tr("Maximum pixels allowed for wallpaper images. 0 = unlimited. Default 200MP for security.")
+                }
+            }
+        }
     }
 }

--- a/.config/quickshell/ii/scripts/colors/generate_colors_material.py
+++ b/.config/quickshell/ii/scripts/colors/generate_colors_material.py
@@ -25,6 +25,7 @@ parser.add_argument('--term_fg_boost', type=float , default=0.35, help='Make ter
 parser.add_argument('--blend_bg_fg', action='store_true', default=False, help='Shift terminal background or foreground towards accent')
 parser.add_argument('--cache', type=str, default=None, help='file path to store the generated color')
 parser.add_argument('--debug', action='store_true', default=False, help='debug mode')
+parser.add_argument('--max-pixels', type=int, default=None, help='Maximum image pixels allowed (None for unlimited)')
 args = parser.parse_args()
 
 rgba_to_hex = lambda rgba: "#{:02X}{:02X}{:02X}".format(rgba[0], rgba[1], rgba[2])
@@ -62,6 +63,10 @@ darkmode = (args.mode == 'dark')
 transparent = (args.transparency == 'transparent')
 
 if args.path is not None:
+    # Set PIL image pixel limit from command line argument
+    if args.max_pixels is not None:
+        Image.MAX_IMAGE_PIXELS = args.max_pixels
+    
     image = Image.open(args.path)
 
     if image.format == "GIF":

--- a/.config/quickshell/ii/scripts/colors/switchwall.sh
+++ b/.config/quickshell/ii/scripts/colors/switchwall.sh
@@ -268,6 +268,14 @@ switch() {
     [[ -n "$type_flag" ]] && matugen_args+=(--type "$type_flag") && generate_colors_material_args+=(--scheme "$type_flag")
     generate_colors_material_args+=(--termscheme "$terminalscheme" --blend_bg_fg)
     generate_colors_material_args+=(--cache "$STATE_DIR/user/generated/color.txt")
+    
+    # Add maxImagePixels from config if specified
+    if [ -f "$SHELL_CONFIG_FILE" ]; then
+        max_pixels=$(jq -r '.appearance.wallpaperTheming.maxImagePixels // 200000000' "$SHELL_CONFIG_FILE")
+        if [ -n "$max_pixels" ]; then
+            generate_colors_material_args+=(--max-pixels "$max_pixels")
+        fi
+    fi
 
     pre_process "$mode_flag"
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ To update the configs:
 ### Common fixes
 - The Dark/Light and theme switcher wont work on first login, please select the "6) Update config files with exclusions" in the setup after your initial login to fix the permission error.
 - If you want to raise your volume above the limit of 90, open `~/.config/illogical-impulse/config.json` and set the max volume allowed to 100. This is just a safety measure.
+- **Terminal colors not loading/invisible text**: If your terminal text appears invisible or colors aren't applying from wallpaper theming, this may be due to large wallpaper images failing color generation. Go to Settings → Advanced → Max image pixels and increase the limit for your wallpaper size. You can set to 0 for unlimited, but be careful with untrusted images as very large files could use excessive memory.
 - If you're experiencing missing or broken icons, try switching your icon pack in the KDE settings and also check troubleshooting steps in the wiki, it's an issue with Adwaita.
 
 ### Keybinds


### PR DESCRIPTION
## Describe your changes

Added configurable PIL image pixel limits to fix terminal colors not loading with large wallpaper images.

**Problem**: Large wallpapers (>200MP) fail PIL's decompression bomb protection, causing terminal color generation to fail and resulting in invisible terminal text.

**Solution**: 
- Added maxImagePixels config option in wallpaperTheming (default 200MP for security)
- Users can adjust in Settings → Advanced → Max image pixels or set to 0 for unlimited
- Updated color generation script to respect the limit
- Added documentation in README Common fixes section

## Is it ready? Questions/feedback needed?

Ready for review. Made it fully configurable as requested in contributing guidelines.